### PR TITLE
Fixed bug with random colours

### DIFF
--- a/src/App_Plugins/CmsEnvironmentIndicator/js/cms-environment-indicator.js
+++ b/src/App_Plugins/CmsEnvironmentIndicator/js/cms-environment-indicator.js
@@ -43,7 +43,7 @@ app.run([function () {
 
 		// fallback on a random HEX colour value
 		// hat-tip: http://www.paulirish.com/2009/random-hex-color-code-snippets/
-		return '#' + Math.floor(Math.random() * 16777215).toString(16);
+		return Math.floor(Math.random() * 16777215).toString(16);
 	}
 
 }]);


### PR DESCRIPTION
When a random colour is picked, the value was prefixed with a hash, which doesn't work with ImageProcessor's tint feature.