### PR TITLE
Test patterns against hostname:port instead of just domain

### DIFF
--- a/src/App_Plugins/CmsEnvironmentIndicator/js/cms-environment-indicator.js
+++ b/src/App_Plugins/CmsEnvironmentIndicator/js/cms-environment-indicator.js
@@ -35,7 +35,7 @@ app.run([function () {
 	function getColor() {
 		if (config) {
 			for (var i in config) {
-				if (new RegExp(config[i].pattern, "i").test(document.domain)) {
+				if (new RegExp(config[i].pattern, "i").test(location.host)) {
 					return config[i].color;
 				}
 			}


### PR DESCRIPTION
With this change you can use the indicator for projects on localhost (with just different ports, not hostnames) as well.

Shouldn't have any side effects on the default umbraco.io rules. Otherwise: @merkledo + sorry ;)